### PR TITLE
Issue-35 Accept Primary Key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem 'activemodel'
 gem 'railties'
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     erubi (1.10.0)
@@ -43,6 +44,9 @@ GEM
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -70,6 +74,7 @@ PLATFORMS
 DEPENDENCIES
   activemodel
   globalid!
+  pry
   railties
   rake
 

--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -46,7 +46,7 @@ class GlobalID
   end
 
   attr_reader :uri
-  delegate :app, :model_name, :model_id, :params, :to_s, to: :uri
+  delegate :app, :model_name, :model_id, :params, :primary_key, :to_s, to: :uri
 
   def initialize(gid, options = {})
     @uri = gid.is_a?(URI::GID) ? gid : URI::GID.parse(gid)

--- a/lib/global_id/locator.rb
+++ b/lib/global_id/locator.rb
@@ -127,7 +127,7 @@ class GlobalID
 
       class BaseLocator
         def locate(gid)
-          gid.model_class.find gid.model_id
+          gid.model_class.find_by(gid.primary_key => gid.model_id)
         end
 
         def locate_many(gids, options = {})

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -22,7 +22,7 @@ end
 
 class GlobalIDParamEncodedTest < ActiveSupport::TestCase
   setup do
-    model = Person.new('id')
+    model = Person.new(id: 'id')
     @gid = GlobalID.create(model)
   end
 
@@ -40,9 +40,9 @@ end
 class GlobalIDCreationTest < ActiveSupport::TestCase
   setup do
     @uuid = '7ef9b614-353c-43a1-a203-ab2307851990'
-    @person_gid = GlobalID.create(Person.new(5))
-    @person_uuid_gid = GlobalID.create(Person.new(@uuid))
-    @person_namespaced_gid = GlobalID.create(Person::Child.new(4))
+    @person_gid = GlobalID.create(Person.new(id: 5))
+    @person_uuid_gid = GlobalID.create(Person.new(uuid: @uuid))
+    @person_namespaced_gid = GlobalID.create(Person::Child.new(id: 4))
     @person_model_gid = GlobalID.create(PersonModel.new(id: 1))
   end
 
@@ -180,21 +180,21 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
   end
 
   test ':app option' do
-    person_gid = GlobalID.create(Person.new(5))
+    person_gid = GlobalID.create(Person.new(id: 5))
     assert_equal 'gid://bcx/Person/5', person_gid.to_s
 
-    person_gid = GlobalID.create(Person.new(5), app: "foo")
+    person_gid = GlobalID.create(Person.new(id: 5), app: "foo")
     assert_equal 'gid://foo/Person/5', person_gid.to_s
 
     assert_raise ArgumentError do
-      person_gid = GlobalID.create(Person.new(5), app: nil)
+      person_gid = GlobalID.create(Person.new(id: 5), app: nil)
     end
   end
 
   test 'equality' do
-    p1 = Person.new(5)
-    p2 = Person.new(5)
-    p3 = Person.new(10)
+    p1 = Person.new(id: 5)
+    p2 = Person.new(id: 5)
+    p3 = Person.new(id: 10)
     assert_equal p1, p2
     assert_not_equal p2, p3
 

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 class GlobalLocatorTest < ActiveSupport::TestCase
   setup do
-    model = Person.new('id')
+    model = Person.new(id: 'id')
     @gid  = model.to_gid
     @sgid = model.to_sgid
   end
@@ -56,18 +56,18 @@ class GlobalLocatorTest < ActiveSupport::TestCase
   end
 
   test 'by many GIDs of one class' do
-    assert_equal [ Person.new('1'), Person.new('2') ],
-      GlobalID::Locator.locate_many([ Person.new('1').to_gid, Person.new('2').to_gid ])
+    assert_equal [ Person.new(id: '1'), Person.new(id: '2') ],
+      GlobalID::Locator.locate_many([ Person.new(id: '1').to_gid, Person.new(id: '2').to_gid ])
   end
 
   test 'by many GIDs of mixed classes' do
-    assert_equal [ Person.new('1'), Person::Child.new('1'), Person.new('2') ],
-      GlobalID::Locator.locate_many([ Person.new('1').to_gid, Person::Child.new('1').to_gid, Person.new('2').to_gid ])
+    assert_equal [ Person.new(id: '1'), Person::Child.new(id: '1'), Person.new(id: '2') ],
+      GlobalID::Locator.locate_many([ Person.new(id: '1').to_gid, Person::Child.new(id: '1').to_gid, Person.new(id: '2').to_gid ])
   end
 
   test 'by many GIDs with only: restriction to match subclass' do
-    assert_equal [ Person::Child.new('1') ],
-      GlobalID::Locator.locate_many([ Person.new('1').to_gid, Person::Child.new('1').to_gid, Person.new('2').to_gid ], only: Person::Child)
+    assert_equal [ Person::Child.new(id: '1') ],
+      GlobalID::Locator.locate_many([ Person.new(id: '1').to_gid, Person::Child.new(id: '1').to_gid, Person.new(id: '2').to_gid ], only: Person::Child)
   end
 
 
@@ -120,18 +120,18 @@ class GlobalLocatorTest < ActiveSupport::TestCase
   end
 
   test 'by many SGIDs of one class' do
-    assert_equal [ Person.new('1'), Person.new('2') ],
-      GlobalID::Locator.locate_many_signed([ Person.new('1').to_sgid, Person.new('2').to_sgid ])
+    assert_equal [ Person.new(id: '1'), Person.new(id: '2') ],
+      GlobalID::Locator.locate_many_signed([ Person.new(id: '1').to_sgid, Person.new(id: '2').to_sgid ])
   end
 
   test 'by many SGIDs of mixed classes' do
-    assert_equal [ Person.new('1'), Person::Child.new('1'), Person.new('2') ],
-      GlobalID::Locator.locate_many_signed([ Person.new('1').to_sgid, Person::Child.new('1').to_sgid, Person.new('2').to_sgid ])
+    assert_equal [ Person.new(id: '1'), Person::Child.new(id: '1'), Person.new(id: '2') ],
+      GlobalID::Locator.locate_many_signed([ Person.new(id: '1').to_sgid, Person::Child.new(id: '1').to_sgid, Person.new(id: '2').to_sgid ])
   end
 
   test 'by many SGIDs with only: restriction to match subclass' do
-    assert_equal [ Person::Child.new('1') ],
-      GlobalID::Locator.locate_many_signed([ Person.new('1').to_sgid, Person::Child.new('1').to_sgid, Person.new('2').to_sgid ], only: Person::Child)
+    assert_equal [ Person::Child.new(id: '1') ],
+      GlobalID::Locator.locate_many_signed([ Person.new(id: '1').to_sgid, Person::Child.new(id: '1').to_sgid, Person.new(id: '2').to_sgid ], only: Person::Child)
   end
 
   test 'by GID string' do
@@ -147,8 +147,8 @@ class GlobalLocatorTest < ActiveSupport::TestCase
   end
 
   test 'by many SGID strings with for: restriction to match purpose' do
-    assert_equal [ Person::Child.new('2') ],
-      GlobalID::Locator.locate_many_signed([ Person.new('1').to_sgid(for: 'adoption').to_s, Person::Child.new('1').to_sgid.to_s, Person::Child.new('2').to_sgid(for: 'adoption').to_s ], for: 'adoption', only: Person::Child)
+    assert_equal [ Person::Child.new(id: '2') ],
+      GlobalID::Locator.locate_many_signed([ Person.new(id: '1').to_sgid(for: 'adoption').to_s, Person::Child.new(id: '1').to_sgid.to_s, Person::Child.new(id: '2').to_sgid(for: 'adoption').to_s ], for: 'adoption', only: Person::Child)
   end
 
   test 'by to_param encoding' do
@@ -246,13 +246,13 @@ class GlobalLocatorTest < ActiveSupport::TestCase
 
   test "by many with one record missing leading to a raise" do
     assert_raises RuntimeError do
-      GlobalID::Locator.locate_many([ Person.new('1').to_gid, Person.new(Person::HARDCODED_ID_FOR_MISSING_PERSON).to_gid ])
+      GlobalID::Locator.locate_many([ Person.new(id: '1').to_gid, Person.new(Person::HARDCODED_ID_FOR_MISSING_PERSON).to_gid ])
     end
   end
 
   test "by many with one record missing not leading to a raise when ignoring missing" do
     assert_nothing_raised do
-      GlobalID::Locator.locate_many([ Person.new('1').to_gid, Person.new(Person::HARDCODED_ID_FOR_MISSING_PERSON).to_gid ], ignore_missing: true)
+      GlobalID::Locator.locate_many([ Person.new(id: '1').to_gid, Person.new(Person::HARDCODED_ID_FOR_MISSING_PERSON).to_gid ], ignore_missing: true)
     end
   end
 
@@ -267,7 +267,7 @@ end
 
 class ScopedRecordLocatingTest < ActiveSupport::TestCase
   setup do
-    @gid = Person::Scoped.new('1').to_gid
+    @gid = Person::Scoped.new(id: '1').to_gid
   end
 
   test "by GID with scoped record" do
@@ -277,12 +277,12 @@ class ScopedRecordLocatingTest < ActiveSupport::TestCase
   end
 
   test "by many with scoped records" do
-    assert_equal [ Person::Scoped.new('1'), Person::Scoped.new('2') ],
-      GlobalID::Locator.locate_many([ Person::Scoped.new('1').to_gid, Person::Scoped.new('2').to_gid ])
+    assert_equal [ Person::Scoped.new(id: '1'), Person::Scoped.new(id: '2') ],
+      GlobalID::Locator.locate_many([ Person::Scoped.new(id: '1').to_gid, Person::Scoped.new(id: '2').to_gid ])
   end
 
   test "by many with scoped and unscoped records" do
-    assert_equal [ Person::Scoped.new('1'), Person.new('2') ],
-      GlobalID::Locator.locate_many([ Person::Scoped.new('1').to_gid, Person.new('2').to_gid ])
+    assert_equal [ Person::Scoped.new(id: '1'), Person.new(id: '2') ],
+      GlobalID::Locator.locate_many([ Person::Scoped.new(id: '1').to_gid, Person.new(id: '2').to_gid ])
   end
 end

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -3,7 +3,7 @@ require 'minitest/mock' # for stubbing Time.now as #travel doesn't have subsecon
 
 class SignedGlobalIDTest < ActiveSupport::TestCase
   setup do
-    @person_sgid = SignedGlobalID.create(Person.new(5))
+    @person_sgid = SignedGlobalID.create(Person.new(id: 5))
   end
 
   test 'as string' do
@@ -19,11 +19,11 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
   end
 
   test 'value equality' do
-    assert_equal SignedGlobalID.create(Person.new(5)), SignedGlobalID.create(Person.new(5))
+    assert_equal SignedGlobalID.create(Person.new(id: 5)), SignedGlobalID.create(Person.new(id: 5))
   end
 
   test 'value equality with an unsigned id' do
-    assert_equal GlobalID.create(Person.new(5)), SignedGlobalID.create(Person.new(5))
+    assert_equal GlobalID.create(Person.new(id: 5)), SignedGlobalID.create(Person.new(id: 5))
   end
 
   test 'to param' do
@@ -33,7 +33,7 @@ end
 
 class SignedGlobalIDVerifierTest < ActiveSupport::TestCase
   setup do
-    @person_sgid = SignedGlobalID.create(Person.new(5))
+    @person_sgid = SignedGlobalID.create(Person.new(id: 5))
   end
 
   test 'parse raises when default verifier is nil' do
@@ -48,21 +48,21 @@ class SignedGlobalIDVerifierTest < ActiveSupport::TestCase
   test 'create raises when default verifier is nil' do
     with_default_verifier nil do
       assert_raise ArgumentError do
-        SignedGlobalID.create(Person.new(5))
+        SignedGlobalID.create(Person.new(id: 5))
       end
     end
   end
 
   test 'create accepts a :verifier' do
     with_default_verifier nil do
-      expected = SignedGlobalID.create(Person.new(5), verifier: VERIFIER)
+      expected = SignedGlobalID.create(Person.new(id: 5), verifier: VERIFIER)
       assert_equal @person_sgid, expected
     end
   end
 
   test 'new accepts a :verifier' do
     with_default_verifier nil do
-      expected = SignedGlobalID.new(Person.new(5).to_gid.uri, verifier: VERIFIER)
+      expected = SignedGlobalID.new(Person.new(id: 5).to_gid.uri, verifier: VERIFIER)
       assert_equal @person_sgid, expected
     end
   end
@@ -77,7 +77,7 @@ end
 
 class SignedGlobalIDPurposeTest < ActiveSupport::TestCase
   setup do
-    @login_sgid = SignedGlobalID.create(Person.new(5), for: 'login')
+    @login_sgid = SignedGlobalID.create(Person.new(id: 5), for: 'login')
   end
 
   test 'sign with purpose when :for is provided' do
@@ -85,20 +85,20 @@ class SignedGlobalIDPurposeTest < ActiveSupport::TestCase
   end
 
   test 'sign with default purpose when no :for is provided' do
-    sgid = SignedGlobalID.create(Person.new(5))
-    default_sgid = SignedGlobalID.create(Person.new(5), for: "default")
+    sgid = SignedGlobalID.create(Person.new(id: 5))
+    default_sgid = SignedGlobalID.create(Person.new(id: 5), for: "default")
 
     assert_equal "eyJnaWQiOiJnaWQ6Ly9iY3gvUGVyc29uLzUiLCJwdXJwb3NlIjoiZGVmYXVsdCIsImV4cGlyZXNfYXQiOm51bGx9--04a6f59140259756b22008c8c0f76ea5ed485579", sgid.to_s
     assert_equal sgid, default_sgid
   end
 
   test 'create accepts a :for' do
-    expected = SignedGlobalID.create(Person.new(5), for: "login")
+    expected = SignedGlobalID.create(Person.new(id: 5), for: "login")
     assert_equal @login_sgid, expected
   end
 
   test 'new accepts a :for' do
-    expected = SignedGlobalID.new(Person.new(5).to_gid.uri, for: 'login')
+    expected = SignedGlobalID.new(Person.new(id: 5).to_gid.uri, for: 'login')
     assert_equal @login_sgid, expected
   end
 
@@ -109,9 +109,9 @@ class SignedGlobalIDPurposeTest < ActiveSupport::TestCase
   end
 
   test 'equal only with same purpose' do
-    expected = SignedGlobalID.create(Person.new(5), for: 'login')
-    like_sgid = SignedGlobalID.create(Person.new(5), for: 'like_button')
-    no_purpose_sgid = SignedGlobalID.create(Person.new(5))
+    expected = SignedGlobalID.create(Person.new(id: 5), for: 'login')
+    like_sgid = SignedGlobalID.create(Person.new(id: 5), for: 'like_button')
+    no_purpose_sgid = SignedGlobalID.create(Person.new(id: 5))
 
     assert_equal @login_sgid, expected
     assert_not_equal @login_sgid, like_sgid
@@ -121,7 +121,7 @@ end
 
 class SignedGlobalIDExpirationTest < ActiveSupport::TestCase
   setup do
-    @uri = Person.new(5).to_gid.uri
+    @uri = Person.new(id: 5).to_gid.uri
   end
 
   test 'expires_in defaults to class level expiration' do
@@ -222,7 +222,7 @@ end
 
 class SignedGlobalIDCustomParamsTest < ActiveSupport::TestCase
   test 'create custom params' do
-    sgid = SignedGlobalID.create(Person.new(5), hello: 'world')
+    sgid = SignedGlobalID.create(Person.new(id: 5), hello: 'world')
     assert_equal 'world', sgid.params[:hello]
   end
 

--- a/test/cases/uri_gid_test.rb
+++ b/test/cases/uri_gid_test.rb
@@ -17,7 +17,7 @@ class URI::GIDTest <  ActiveSupport::TestCase
   end
 
   test 'create' do
-    model = Person.new('5')
+    model = Person.new(id: '5')
     assert_equal @gid_string, URI::GID.create('bcx', model).to_s
   end
 
@@ -47,12 +47,12 @@ end
 
 class URI::GIDModelIDEncodingTest < ActiveSupport::TestCase
   test 'alphanumeric' do
-    model = Person.new('John123')
+    model = Person.new(id: 'John123')
     assert_equal 'gid://app/Person/John123', URI::GID.create('app', model).to_s
   end
 
   test 'non-alphanumeric' do
-    model = Person.new('John Doe-Smith/Jones')
+    model = Person.new(id: 'John Doe-Smith/Jones')
     assert_equal 'gid://app/Person/John+Doe-Smith%2FJones', URI::GID.create('app', model).to_s
   end
 end

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 class Person
   include GlobalID::Identification
 
@@ -15,17 +17,28 @@ class Person
       if id == HARDCODED_ID_FOR_MISSING_PERSON
         raise 'Person missing'
       else
-        new(id)
+        new(id: id)
       end
     end
   end
 
-  def self.where(conditions)
-    (conditions[:id] - [HARDCODED_ID_FOR_MISSING_PERSON]).collect { |id| new(id) }
+  def self.find_by(args)
+    find_by_options = args.with_indifferent_access
+    if find_by_options[:id].present? && find_by_options[:id] == HARDCODED_ID_FOR_MISSING_PERSON
+      raise 'Person missing'
+    else
+      new(find_by_options)
+    end
   end
 
-  def initialize(id = 1)
-    @id = id
+  def self.where(conditions)
+    (conditions[:id] - [HARDCODED_ID_FOR_MISSING_PERSON]).collect { |id| new(id: id) }
+  end
+
+  def initialize(**args)
+    args.each do |k, v|
+      define_singleton_method(k) { v }
+    end
   end
 
   def ==(other)

--- a/test/models/person_model.rb
+++ b/test/models/person_model.rb
@@ -4,7 +4,7 @@ class PersonModel
   include ActiveModel::Model
   include GlobalID::Identification
 
-  attr_accessor :id
+  attr_accessor :id, :uuid
 
   def self.find(id)
     new id: id


### PR DESCRIPTION
- Allow a primary_key argument
- Switch to find_by instead of find
- Only encode primary_key in uri if it is not id
- Start to adjust tests